### PR TITLE
Disable comments when comment status is closed for the post

### DIFF
--- a/disqus.php
+++ b/disqus.php
@@ -144,6 +144,7 @@ function dsq_can_replace() {
 
     if ( is_feed() )                       { return false; }
     if ( 'draft' == $post->post_status )   { return false; }
+    if ( 'closed' == $post->comment_status ) { return false; }
     if ( !get_option('disqus_forum_url') ) { return false; }
     else if ( 'all' == $replace )          { return true; }
 


### PR DESCRIPTION
Currently, Disqus plugin doesn't work when setting for auto-disable comments after given days is enabled

![screencap](http://i.imgur.com/OTQdQ.png)
