### PR TITLE
Defer to username if user hasn't entered a display_name, fixes #4

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -305,7 +305,11 @@ function dsq_sync_comments($comments) {
                 $commentdata['comment_author_url'] = $comment->anonymous_author->url;
                 $commentdata['comment_author_IP'] = $comment->anonymous_author->ip_address;
             } else {
-                $commentdata['comment_author'] = $comment->author->display_name;
+                if isset($comment->author->display_name) {
+                    $commentdata['comment_author'] = $comment->author->display_name;
+                } else {
+                    $commentdata['comment_author'] = $comment->author->username;
+                }
                 $commentdata['comment_author_email'] = $comment->author->email;
                 $commentdata['comment_author_url'] = $comment->author->url;
                 $commentdata['comment_author_IP'] = $comment->author->ip_address;


### PR DESCRIPTION
Currently commenters' names are synced back as Anonymous if they are a registered Disqus user who hasn't entered a display name. We should defer to their username in this scenario.

Example -- top three are after I set a display name for the account, bottom three were before:
![Example screenshot](http://dl.dropbox.com/u/15229959/Screenshots/0_7.png)
