### PR TITLE
Load embed via SSL if page is loaded via HTTPS

### DIFF
--- a/disqus/comments.php
+++ b/disqus/comments.php
@@ -122,7 +122,7 @@ if (DISQUS_DEBUG) {
     var dsq = document.createElement('script'); dsq.type = 'text/javascript';
     dsq.async = true;
     <?php
-    if(isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS'])) {
+    if (is_ssl()) {
         $connection_type = "https";
     } else {
         $connection_type = "http";


### PR DESCRIPTION
Pretty sure this is the most bullet-proof way to determine if the page is loaded via HTTPS.

Should this variable be defined elsewhere? 
