### PR TITLE
Avoids double scrollbar issue in the embedded admin

### DIFF
--- a/disqus/manage.php
+++ b/disqus/manage.php
@@ -226,7 +226,7 @@ case 0:
                 echo 'http://'.$url.'.'.DISQUS_DOMAIN.'/admin/moderate/';
             } else {
                 echo DISQUS_URL.'admin/moderate/';
-            } ?>?template=wordpress" style="width: 100%; height: 800px"></iframe>
+            } ?>?template=wordpress" style="width: 100%; height: 80%"></iframe>
         </div>
 <?php } ?>
     </div>


### PR DESCRIPTION
800px creates two scrollbars in windows < 800px tall.  Changing to 80% height fixes by always making iframe a proportinal amount of window height.
