### PR TITLE
Custom configuration

### DIFF
--- a/disqus/comments.php
+++ b/disqus/comments.php
@@ -82,6 +82,9 @@ if (DISQUS_DEBUG) {
             }
         }
         ?>
+        if (typeof disqus_custom_config !== "undefined") {
+          disqus_custom_config(config);
+        }
     };
     var facebookXdReceiverPath = '<?php echo DSQ_PLUGIN_URL . '/xd_receiver.htm' ?>';
 /* ]]> */


### PR DESCRIPTION
I thought that it may be helpful to be able to configure disqus (in my case I need to add a callback for tracking via google analytics http://docs.disqus.com/help/60/). So this simple change allows to define a `disqus_custom_config` function that'll be executed by the plugin.
