### PR TITLE
CDATA patch

### DIFF
--- a/disqus/export.php
+++ b/disqus/export.php
@@ -41,7 +41,7 @@ function dsq_export_wxr_cdata($str) {
 
     // $str = ent2ncr(esc_html($str));
 
-    $str = "<![CDATA[$str" . ( ( substr($str, -1) == ']' ) ? ' ' : '') . "]]>";
+    $str = '<![CDATA[' . str_replace( ']]>', ']]]]><![CDATA[>', $str ) . ']]>';
 
     return $str;
 }


### PR DESCRIPTION
Apply CDATA patch from Wordpress 3.4 to dsq_export_wxr_cdata() - see http://wordpress.org/support/topic/plugin-disqus-comment-system-posts-containing-cdata-break-wxrdisqus-exports-db-disqus-patch-included for more info.
