### PR TITLE
Prevent 404 errors for embed.js from being reported by webmaster tools

### DIFF
--- a/disqus/comments.php
+++ b/disqus/comments.php
@@ -128,7 +128,7 @@ if (DISQUS_DEBUG) {
         $connection_type = "http";
     }
     ?>
-    dsq.src = '<?php echo $connection_type; ?>' + '://' + disqus_shortname + '.' + disqus_domain + '/embed.js?pname=wordpress&pver=<?php echo DISQUS_VERSION; ?>';
+    dsq.src = '<?php echo $connection_type; ?>' + '://' + disqus_shortname + '.' + '<?php echo DISQUS_DOMAIN; ?>' + '/embed.js?pname=wordpress&pver=<?php echo DISQUS_VERSION; ?>';
     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 })();
 /* ]]> */


### PR DESCRIPTION
The original commit (https://github.com/disqus/disqus-wordpress/pull/14) only covered count.js
