### PR TITLE
Use wp_new_comment instead of wp_insert_comment?

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -334,7 +334,7 @@ function dsq_sync_comments($comments) {
                 continue;
             }
 
-            $commentdata['comment_ID'] = wp_insert_comment($commentdata);
+            $commentdata['comment_ID'] = wp_new_comment($commentdata);
             if (DISQUS_DEBUG) {
                 echo "inserted {$comment->id}: id is {$commentdata[comment_ID]}\n";
             }


### PR DESCRIPTION
Calling wp_insert_comment bypasses WordPress' internal systems, including many filters and actions, as well as moderator and author notifications. Submitted for your consideration. Thank you!
