### PR TITLE
Added a check to make sure the array key exists to avoid a notice.

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -932,7 +932,7 @@ function dsq_dash_comment_counts() {
     $known_types = array_keys( $approved );
     foreach( (array) $count as $row_num => $row ) {
         $total += $row['num_comments'];
-        if ( in_array( $row['comment_approved'], $known_types ) )
+        if ( in_array( $row['comment_approved'], $known_types ) && array_key_exists($row['comment_approved'], $approved) )
             $stats[$approved[$row['comment_approved']]] = $row['num_comments'];
     }
 


### PR DESCRIPTION
Added a check to make sure the array key exists to avoid a notice when WP_DEBUG is set to TRUE.

On WordPress installs that have `WP_DEBUG` set to `TRUE`, the following notice is displayed:

```
Notice: Undefined index: post-trashed in /path/to/public_html/wp-content/plugins/disqus-comment-system/disqus.php on line 936
```

This doesn't seem to affect the plugin's operation, so simply adding a check for the existence of the index removes the notice and shouldn't pose any issues for the plugin's operation.

This notice appears in WordPress 3.4.2 and 3.5 with `WP_DEBUG` enabled.. It may occur in older versions, but I didn't bother to check.
