### PR TITLE
Add filter hook for setting custom Disqus language

### DIFF
--- a/disqus/comments.php
+++ b/disqus/comments.php
@@ -54,6 +54,7 @@ if (DISQUS_DEBUG) {
     <?php endif; ?>
     var disqus_config = function () {
         var config = this; // Access to the config object
+        config.language = '<?php echo esc_js(apply_filters('disqus_language_filter', '')) ?>';
 
         /*
            All currently supported events:


### PR DESCRIPTION
This will allow plugins like WPML (http://wpml.org/) to tap into a filter hook for setting the language in the Disqus embed.
