### PR TITLE
Fix wpdb::prepare() call in dsq_sync_comments()

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -282,7 +282,7 @@ function dsq_sync_comments($comments) {
 
         // and follow up using legacy Disqus agent
         if (!$commentdata) {
-            $commentdata = $wpdb->get_row($wpdb->prepare( "SELECT comment_ID, comment_parent FROM $wpdb->comments WHERE comment_agent = 'Disqus/1.0:{$comment->id}' LIMIT 1"), ARRAY_A);
+            $commentdata = $wpdb->get_row($wpdb->prepare( "SELECT comment_ID, comment_parent FROM $wpdb->comments WHERE comment_agent = 'Disqus/1.0:%d' LIMIT 1", $comment->id ), ARRAY_A);
         }
         if (!$commentdata) {
             // Comment doesnt exist yet, lets insert it


### PR DESCRIPTION
Since WP 3.5 wpdb::prepare() expects 2 arguments. The prepare() call in dsq_sync_comments() currently does not supply the second argument to actually prepare the statement .

This should fix https://github.com/disqus/disqus-wordpress/issues/46
