### PR TITLE
Use wordpress language to determine disqus lang

### DIFF
--- a/disqus/comments.php
+++ b/disqus/comments.php
@@ -54,7 +54,8 @@ if (DISQUS_DEBUG) {
     <?php endif; ?>
     var disqus_config = function () {
         var config = this; // Access to the config object
-        config.language = '<?php echo esc_js(apply_filters('disqus_language_filter', '')) ?>';
+        <?php $wplang = get_bloginfo('language'); ?>
+        config.language = '<?php echo (!empty($wplang)) ? $wplang : esc_js(apply_filters('disqus_language_filter', '')) ?>';
 
         /*
            All currently supported events:


### PR DESCRIPTION
People use multisite install with different languages. Each site should load disqus in the language it is defined in.

Additional checking could be done on the $wplang variable to see if it is available at disqus and if not default to the disqus configuration one.

A better solution would be to offer a dropdown in the disqus wordpress settings page to chose the language. All problem would then be solved.
