### PR TITLE
Removed assignment by reference

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -1237,7 +1237,7 @@ $dsq_prev_permalinks = array();
 
 function dsq_prev_permalink($post_id) {
 // if post not published, return
-    $post = &get_post($post_id);
+    $post = get_post($post_id);
     if ($post->post_status != 'publish') {
         return;
     }


### PR DESCRIPTION
The use of the ampersand to assign the output of `get_post()` by reference throws a strict standards warning. From what I can tell, it doesn't appear to be necessary in the context of `dsq_prev_permalink()`.
