### PR TITLE
Change default timeout of 5 seconds to 60 seconds so that imports from t...

### DIFF
--- a/disqus/lib/wp-api.php
+++ b/disqus/lib/wp-api.php
@@ -79,6 +79,7 @@ class DisqusWordPressAPI {
             DISQUS_IMPORTER_URL . 'api/import-wordpress-comments/',
             array(
                 'method' => 'POST',
+                'timeout' => 60,
                 'body' => array(
                     'forum_url' => $this->short_name,
                     'forum_api_key' => $this->forum_api_key,


### PR DESCRIPTION
My import dies every few posts because of the 5s default timeout in Word Press's WP_Http class. This one line change modifies it to 60s, which was more than enough to allow my 5k comments to be imported successfully.
