### PR TITLE
Incrase HTTP request timeout to 60s

### DIFF
--- a/disqus/lib/wp-api.php
+++ b/disqus/lib/wp-api.php
@@ -86,7 +86,8 @@ class DisqusWordPressAPI {
                     'wxr' => $wxr,
                     'timestamp' => $timestamp,
                     'eof' => (int)$eof
-                )
+                ),
+                'timeout' => '60'
             )
         );
         if ($response->errors) {


### PR DESCRIPTION
Our sites always failed to "Export comments to Disqus". After inspection, I found that the connection was timeout.
