### PR TITLE
Get rid of wpdb:prepare warning in comment sync

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -282,7 +282,7 @@ function dsq_sync_comments($comments) {
 
         // and follow up using legacy Disqus agent
         if (!$commentdata) {
-            $commentdata = $wpdb->get_row($wpdb->prepare( "SELECT comment_ID, comment_parent FROM $wpdb->comments WHERE comment_agent = 'Disqus/1.0:{$comment->id}' LIMIT 1"), ARRAY_A);
+            $commentdata = $wpdb->get_row($wpdb->prepare( "SELECT comment_ID, comment_parent FROM $wpdb->comments WHERE comment_agent = 'Disqus/1.0:%d' LIMIT 1", $comment->id ), ARRAY_A);
         }
         if (!$commentdata) {
             // Comment doesnt exist yet, lets insert it


### PR DESCRIPTION
This gets rid of "PHP Warning:  Missing argument 2 for wpdb::prepare(), called in /var/web/cott/stupidlaws/stupidlaws.com/wp-content/plugins/disqus-comment-system/disqus.php on line 285" on comment sync.
