### PR TITLE
Allow theme developers to use their own comments template

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -802,10 +802,16 @@ function dsq_comments_template($value) {
         return $value;
     }
 
-    // TODO: If a disqus-comments.php is found in the current template's
-    // path, use that instead of the default bundled comments.php
-    //return TEMPLATEPATH . '/disqus-comments.php';
     $EMBED = true;
+    
+    $custom_template = locate_template( apply_filters( 'dsq_custom_template', 'disqus-comments.php' ) );
+    if( !empty( $custom_template ) ) {
+        return $custom_template;
+    }
+    return dsq_get_default_comments_template_file();
+}
+
+function dsq_get_default_comments_template_file() {
     return dirname(__FILE__) . '/comments.php';
 }
 


### PR DESCRIPTION
The function `dsq_comments_template()` has been modified to look for a theme template named 'disqus-comments.php' (filename can be filtered). If this is not found, the default template will be used. Furthermore a function `dsq_get_default_comments_template_file()` has been added.

These modifications allow theme developers to be more flexible using Disqus. They may filter the requested file name to adjust it as they wish. The newly added function furthermore allows them to easily include the original template inside their own template. This might be a use-case for example if the developer only wants to wrap the Disqus Comments with some custom design code.
