### PR TITLE
Better HTTP response error test

### DIFF
--- a/disqus/lib/wp-api.php
+++ b/disqus/lib/wp-api.php
@@ -90,7 +90,7 @@ class DisqusWordPressAPI {
                 ),
             )
         );
-        if ($response->errors) {
+        if (is_wp_error($response)) {
             // hack
             $this->api->last_error = $response->errors;
             return -1;


### PR DESCRIPTION
The original test gives a PHP notice (if WP_DEBUG is on), and thus errors in the admin page (when parsing the response as JSON).
