### PR TITLE
Adding option to show Disqus comments on click

### DIFF
--- a/disqus/comments.php
+++ b/disqus/comments.php
@@ -11,6 +11,12 @@ if (DISQUS_DEBUG) {
         //     include(TEMPLATEPATH . '/comments.php');
         // }
         ?>
+<?php if (get_option('disqus_onclick')): ?>
+        <div id="dsq-onclick">
+            <a href="javascript:dsq_onclick();" title="<?php echo dsq_i('Join the Discussion') ?>"><?php echo dsq_i('Join the Discussion') ?></a>
+        </div>
+<?php endif; // check for on click functionality ?>
+
         <div id="dsq-content">
 
 <?php if (get_comment_pages_count() > 1 && get_option('page_comments')): // Are there comments to navigate through? ?>
@@ -41,11 +47,23 @@ if (DISQUS_DEBUG) {
     <?php endif; ?>
 </div>
 
+<?php if (get_option('disqus_onclick')): ?>
+<script type="text/javascript">
+/* <![CDATA[ */
+    function dsq_onclick() {
+        dsq_show();
+        return false;
+    }
+/* ]]> */
+</script>
+<?php endif; // check for on click functionality ?>
+
 <script type="text/javascript">
 /* <![CDATA[ */
     var disqus_url = '<?php echo get_permalink(); ?>';
     var disqus_identifier = '<?php echo dsq_identifier_for_post($post); ?>';
     var disqus_container_id = 'disqus_thread';
+    var disqus_content_id = 'dsq-content';
     var disqus_domain = '<?php echo DISQUS_DOMAIN; ?>';
     var disqus_shortname = '<?php echo strtolower(get_option('disqus_forum_url')); ?>';
     var disqus_title = <?php echo cf_json_encode(dsq_title_for_post($post)); ?>;
@@ -68,10 +86,12 @@ if (DISQUS_DEBUG) {
             * onReady - everything is done
          */
 
+        <?php if (!get_option('disqus_onclick')): ?>
         config.callbacks.preData.push(function() {
             // clear out the container (its filled for SEO/legacy purposes)
             document.getElementById(disqus_container_id).innerHTML = '';
         });
+        <?php endif; ?>
         <?php if (!get_option('disqus_manual_sync')): ?>
         config.callbacks.onReady.push(function() {
             // sync comments in the background so we don't block the page
@@ -127,11 +147,20 @@ if (DISQUS_DEBUG) {
 
 <script type="text/javascript">
 /* <![CDATA[ */
+<?php if (!get_option('disqus_onclick')): ?>
 (function() {
+<?php else: ?>
+document.getElementById(disqus_content_id).innerHTML = '';
+function dsq_show() {
+<?php endif; // check for on click functionality ?>
     var dsq = document.createElement('script'); dsq.type = 'text/javascript';
     dsq.async = true;
     dsq.src = '//' + disqus_shortname + '.' + '<?php echo DISQUS_DOMAIN; ?>' + '/embed.js?pname=wordpress&pver=<?php echo DISQUS_VERSION; ?>';
     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+<?php if (!get_option('disqus_onclick')): ?>
 })();
+<?php else: ?> 
+}
+<?php endif; // check for on click functionality ?>
 /* ]]> */
 </script>

--- a/disqus/manage.php
+++ b/disqus/manage.php
@@ -248,6 +248,7 @@ case 0:
     $dsq_user_api_key = get_option('disqus_user_api_key');
     $dsq_partner_key = get_option('disqus_partner_key');
     $dsq_cc_fix = get_option('disqus_cc_fix');
+    $disqus_onclick = get_option('disqus_onclick');
     $dsq_manual_sync = get_option('disqus_manual_sync');
     $dsq_disable_ssr = get_option('disqus_disable_ssr');
     $dsq_public_key = get_option('disqus_public_key');
@@ -296,6 +297,14 @@ case 0:
                     </select>
                     <br />
                     <?php echo dsq_i('Your WordPress comments will never be lost.'); ?>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row" valign="top"><?php echo dsq_i('Load Disqus Comments on Click'); ?></th>
+                <td>
+                    <input type="checkbox" name="disqus_onclick" class="disqus-onclick" <?php if($disqus_onclick){echo 'checked="checked"';}?> >
+                    <label for="disqus_onclick"><?php echo dsq_i('Disable client-side rendering of comments until a button is clicked'); ?></label>
+                    <br /><?php echo dsq_i('Your WordPress comments will show when your users click a button instead of on page load.'); ?>
                 </td>
             </tr>
 


### PR DESCRIPTION
This option adds the ability to show Disqus comments when the user clicks a button (Join the Discussion). The button needs some styling and the text will need to be translated, though. Other than that, this works the way you'd expect.

![screen shot 2014-04-29 at 5 17 10 pm](https://cloud.githubusercontent.com/assets/414475/2835007/c1d77c7e-cfe3-11e3-97f3-63a0f7836aaa.png)
![screen shot 2014-04-29 at 5 17 38 pm](https://cloud.githubusercontent.com/assets/414475/2835008/c1d84262-cfe3-11e3-8366-73e5002dd9c3.png)
