### PR TITLE
DSQ_PLUGIN_URL uses WP_PLUGIN_URL

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -92,7 +92,7 @@ if ( !defined('PLUGINDIR') ) {
     define('PLUGINDIR', 'wp-content/plugins'); // Relative to ABSPATH.  For back compat.
 }
 
-define('DSQ_PLUGIN_URL', WP_PLUGIN_URL . '/' . dsq_plugin_basename(__FILE__));
+define('DSQ_PLUGIN_URL', plugins_url() . '/' . dsq_plugin_basename(__FILE__));
 
 $mt_disqus_version = '2.01';
 /**


### PR DESCRIPTION
Don't assume my plugins dir is in my WP_CONTENT_DIR.
