### PR TITLE
Wpdbfix

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -693,7 +693,7 @@ function dsq_clear_pending_post_ids($post_ids) {
     // add as many placeholders as needed
     $sql = "
         DELETE FROM {$wpdb->postmeta} 
-        WHERE meta_key = 'dsq_needs_sync' AND post_id IN ((".implode(', ', array_fill(0, count($post_ids), '%s')).")
+        WHERE meta_key = 'dsq_needs_sync' AND post_id IN (".implode(', ', array_fill(0, count($post_ids), '%s')).")
     ";
 
     // Call $wpdb->prepare passing the values of the array as separate arguments


### PR DESCRIPTION
Arrays are not passed to $wpdb correctly because quotes are escaped by $wpdb->prepare().
This returns wrong results for the two requests using the IN () operator.

I switch to the a solution advised here : http://stackoverflow.com/a/10634225/632487

In function dsq_sync_comments there also was _i think_ a wrong "LIMIT 1" clause.
