### PR TITLE
Added a filter to the start of dsq_can_replace() function

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -222,7 +222,9 @@ function dsq_is_installed() {
  */
 function dsq_can_replace() {
     global $id, $post;
-
+    
+    if (apply_filters( 'dsq_can_replace_filter', false )){ return false; }// NomadDevs 13-Dec-2014
+    
     if (get_option('disqus_active') === '0'){ return false; }
 
     $replace = get_option('disqus_replace');


### PR DESCRIPTION
The added filter allows disqus to be disabled on the fly.  By adding this filter developers can disable disqus on diffrent post types or even per post etc.
The below example would disable disqus comments system for Custom Post Types places and events, which could be required if they have their own review system rather than a comments system.
Example:

add_filter('dsq_can_replace_filter','dsq_can_replace_begin_hook_change',10);

function dsq_can_replace_begin_hook_change(){
global $post;
if(isset($post->post_type) && $post->post_type && in_array($post->post_type,array('places','events'))){return true;}
}