### PR TITLE
apply the 'dsq_link_for_post' filter before returning the post link

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -1437,7 +1437,7 @@ function dsq_title_for_post($post) {
 }
 
 function dsq_link_for_post($post) {
-    return get_permalink($post);
+    return apply_filters('dsq_link_for_post', get_permalink($post));
 }
 
 function dsq_does_need_update() {


### PR DESCRIPTION
This filter allows the theme developer to customize the disqusUrl used for a post, using

```
add_filter('dsq_link_for_post', function($url) { return "modified $url"; });
```

It's useful when you have multiple urls for a single site (i.e. wordpress admin on a different domain), avoiding this problem https://help.disqus.com/customer/portal/articles/735138-why-are-the-wrong-urls-detected-for-my-discussions-
