### PR TITLE
Clear unused scheduled events in wp_options cron.

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -510,6 +510,7 @@ function dsq_request_handler() {
                         die('// synced '.$comments.' comments');
                     }
                 } else {
+                    wp_clear_scheduled_hook( 'dsq_sync_forum' );
                     $ts = time() + 300;
                     wp_schedule_single_event($ts, 'dsq_sync_forum');
                     die('// sync scheduled');


### PR DESCRIPTION
Clears unused scheduled events in wp_options cron before adding a new
scheduled event. Prevents server exhaustion and several problems when having heavy loads of information in wp_options cron. 

Solves
https://disqus.com/home/channel/discussdisqus/discussion/channel-discuss
disqus/tons_of_dsq_sync_forum_entries_in_cron_row_wp_options_and_10x_ser
ver_loads/
Solves
https://wordpress.org/support/topic/high-server-load-and-dsq_sync_forum-
problem