### PR TITLE
Forcing HTTPs when loading disqus when is_ssl() is true

### DIFF
--- a/disqus/comments.php
+++ b/disqus/comments.php
@@ -144,7 +144,7 @@ var disqus_config = function () {
 (function() {
     var dsq = document.createElement('script'); dsq.type = 'text/javascript';
     dsq.async = true;
-    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js<?php if (is_ssl()) { echo '?https'; } ?>';
     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 })();
 </script>


### PR DESCRIPTION
Based on the content found in the following help page:
https://help.disqus.com/customer/portal/articles/542119-can-disqus-be-loaded-via-https-
