### PR TITLE
Allow for safe / naive inlining of JS

### DIFF
--- a/disqus/comments.php
+++ b/disqus/comments.php
@@ -126,7 +126,7 @@ var disqus_config = function () {
     <?php if (!get_option('disqus_manual_sync')): ?>
     this.callbacks.onReady.push(function () {
 
-        // sync comments in the background so we don't block the page
+        /* sync comments in the background so we don't block the page */
         var script = document.createElement('script');
         script.async = true;
         script.src = '?cf_action=sync_comments&post_id=<?php echo esc_attr( $post->ID ); ?>';

--- a/disqus/media/js/disqus.js
+++ b/disqus/media/js/disqus.js
@@ -33,7 +33,7 @@ var disqus_config = function () {
     this.language = embedVars.disqusConfig.language;
     this.callbacks.onReady.push(function () {
         if (!embedVars.options.manualSync) {
-            // sync comments in the background so we don't block the page
+            /* sync comments in the background so we don't block the page */
             var script = document.createElement('script');
             script.async = true;
             script.src = '?cf_action=sync_comments&post_id=' + embedVars.postId;

--- a/disqus/media/js/pointer.js
+++ b/disqus/media/js/pointer.js
@@ -3,13 +3,13 @@ jQuery(document).ready( function($) {
     $('#menu-comments').pointer({
         content: pointerContent,
         position: {
-            edge: 'left', // arrow direction
-            align:  'center' // vertical alignment
+            edge: 'left', /* arrow direction */
+            align:  'center' /* vertical alignment */
         },
         pointerWidth: 350,
         close: function() {
             $.post(ajaxurl, {
-                pointer: 'disqus_settings_pointer', // pointer ID
+                pointer: 'disqus_settings_pointer', /* pointer ID */
                 action: 'dismiss-wp-pointer'
             });
         }


### PR DESCRIPTION
We see that sometime the JS from this plugin get inlined, during the creation of the final response from wordpress.  In those times, the JS breaks and the interactive Disqus element doesn't load.  

This is due to some comment lines simply starting with `//`.  When inlined, these cause all subsequent JS to be ignored.  

To get around this, we change the comments to use open-close style `/* xx */`, which allows inlining.
