### PR TITLE
Globalize $dsq_api

### DIFF
--- a/disqus/disqus.php
+++ b/disqus/disqus.php
@@ -90,6 +90,7 @@ $dsq_response = '';
  * @global    string    $dsq_api
  * @since    1.0
  */
+global $dsq_api;
 $dsq_api = new DisqusWordPressAPI(get_option('disqus_forum_url'), get_option('disqus_api_key'));
 
 /**


### PR DESCRIPTION
When using WP-CLI from the command line the global variables has to be globalized to work - declaring in the global namespace is not enough.

This fixed a really bad issue that results in a fatal error on `dsq_sync_forum` cronjobs if triggered from WP-CLI: https://developer.wordpress.org/cli/commands/cron/event/run/

`wp cron event run --due-now`

Before/After tests:

`wp cron event schedule dsq_sync_forum && wp cron event run dsq_sync_forum`

```
┌──────────────────────────────────────────────────────────────────────────────┐
│                                   $dsq_api                                   │
└──────────────────────────────────────────────────────────────────────────────┘
NULL
```


`wp cron event schedule dsq_sync_forum && wp cron event run dsq_sync_forum`

```
┌──────────────────────────────────────────────────────────────────────────────┐
│                                   $dsq_api                                   │
└──────────────────────────────────────────────────────────────────────────────┘
DisqusWordPressAPI (4) (
    public short_name -> string (10) "..."
    public forum_api_key -> string (64) "..."
    public user_api_key -> NULL
    public api -> DisqusAPI (5) (
        public user_api_key -> NULL
        public forum_api_key -> string (64) "..."
        public api_url -> string (22) "http://disqus.com/api/"
        public api_version -> string (3) "1.1"
        public last_error -> NULL
    )
)
```

Fixes #123 